### PR TITLE
macOS UI: “Send Monero” sheet using local bridge

### DIFF
--- a/bitchat/Monero/SendXMRSheet.swift
+++ b/bitchat/Monero/SendXMRSheet.swift
@@ -1,0 +1,84 @@
+﻿import SwiftUI
+
+struct SendXMRSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    private let xmr = XMRClient()
+
+    @State private var address = ""
+    @State private var amountStr = "0.005"
+    @State private var fee: Double?
+    @State private var txid = ""
+    @State private var status = ""
+    @State private var isBusy = false
+    @State private var error: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Send Monero").font(.title2).bold()
+
+            TextField("Destination address", text: )
+                .textFieldStyle(.roundedBorder)
+
+            HStack(spacing: 12) {
+                TextField("Amount (XMR)", text: )
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 180)
+                if let f = fee {
+                    Text("Fee ≈ \(String(format: "%.8f", f)) XMR")
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+
+            if !txid.isEmpty {
+                Text("txid: \(txid)").font(.footnote).textSelection(.enabled)
+            }
+            if !status.isEmpty {
+                Text(status).font(.footnote).foregroundStyle(.secondary)
+            }
+            if let e = error {
+                Text(e).foregroundStyle(.red).font(.footnote)
+            }
+
+            HStack {
+                Button("Estimate") { Task { await doEstimate() } }.disabled(isBusy)
+                Button("Send") { Task { await doSend() } }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isBusy || fee == nil)
+                Spacer()
+                Button("Close") { dismiss() }
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 520)
+    }
+
+    private func amount() -> Double? { Double(amountStr.replacingOccurrences(of: ",", with: ".")) }
+
+    private func doEstimate() async {
+        error = nil; fee = nil; status = ""
+        guard let amt = amount(), !address.isEmpty else { error = "Enter address and amount"; return }
+        isBusy = true; defer { isBusy = false }
+        do {
+            let r = try await xmr.estimate(address: address, amount: amt)
+            fee = r.feeXmr
+        } catch { self.error = error.localizedDescription }
+    }
+
+    private func doSend() async {
+        error = nil; status = ""; txid = ""
+        guard let amt = amount(), !address.isEmpty else { error = "Enter address and amount"; return }
+        isBusy = true; defer { isBusy = false }
+        do {
+            let r = try await xmr.transfer(address: address, amount: amt)
+            txid = r.txid ?? r.txHash ?? ""
+            status = "Broadcasted. Waiting for confirmations…"
+            while true {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                let t = try await xmr.txStatus(txid: txid)
+                status = "Confirmations: \(t.confirmations)"
+                if t.confirmations >= 1 { break }
+            }
+        } catch { self.error = error.localizedDescription }
+    }
+}

--- a/bitchat/Monero/XMRService.swift
+++ b/bitchat/Monero/XMRService.swift
@@ -1,0 +1,87 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+#endif
+
+// Basic config
+enum XMRConfig {
+    static let baseURL = URL(string: "http://127.0.0.1:8787")! // your bridge
+    static let apiKey: String? = nil // set if you enabled XMR_BRIDGE_KEY
+}
+
+// Generic client
+final class XMRClient {
+    private let session: URLSession = .shared
+
+    private func makeRequest(path: String, method: String = "GET", json: Any? = nil) throws -> URLRequest {
+        var req = URLRequest(url: XMRConfig.baseURL.appendingPathComponent(path))
+        req.httpMethod = method
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let k = XMRConfig.apiKey { req.setValue(k, forHTTPHeaderField: "x-api-key") }
+        if let json {
+            req.httpBody = try JSONSerialization.data(withJSONObject: json, options: [])
+        }
+        return req
+    }
+
+    private func decode<T: Decodable>(_ data: Data) throws -> T {
+        let dec = JSONDecoder()
+        dec.keyDecodingStrategy = .convertFromSnakeCase
+        return try dec.decode(T.self, from: data)
+    }
+
+    // MARK: DTOs
+    struct Health: Decodable { let ok: Bool; let version: Int?; let release: Bool? }
+    struct AddressResp: Decodable { let ok: Bool?; let address: String; let addressIndex: Int?; let accountIndex: Int? }
+    struct EstimateResp: Decodable { let feeXmr: Double; let txMetadata: String }
+    struct TransferResp: Decodable { let ok: Bool?; let txid: String?; let txHash: String?; let feeXmr: Double? }
+    struct TxResp: Decodable { let ok: Bool?; let txid: String; let inPool: Bool; let confirmations: Int; let amountXmr: Double; let feeXmr: Double?; let timestamp: TimeInterval? }
+    struct ProofResp: Decodable { let ok: Bool?; let txid: String; let address: String; let message: String?; let signature: String }
+    struct VerifyResp: Decodable { let ok: Bool?; let good: Bool; let inPool: Bool; let receivedXmr: Double }
+
+    // MARK: Calls
+    func health() async throws -> Health {
+        let req = try makeRequest(path: "health")
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func createAddress(label: String) async throws -> AddressResp {
+        let req = try makeRequest(path: "address", method: "POST", json: ["label": label])
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func estimate(address: String, amount: Double) async throws -> EstimateResp {
+        let req = try makeRequest(path: "estimate", method: "POST", json: ["address": address, "amount": amount])
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func transfer(address: String, amount: Double) async throws -> TransferResp {
+        let req = try makeRequest(path: "transfer", method: "POST", json: ["address": address, "amount": amount])
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func txStatus(txid: String) async throws -> TxResp {
+        let req = try makeRequest(path: "tx/\(txid)")
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func createProof(txid: String, address: String, message: String?) async throws -> ProofResp {
+        var body: [String: Any] = ["txid": txid, "address": address]
+        if let m = message { body["message"] = m }
+        let req = try makeRequest(path: "proof", method: "POST", json: body)
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func verifyProof(txid: String, address: String, message: String?, signature: String) async throws -> VerifyResp {
+        let req = try makeRequest(path: "verify", method: "POST",
+                                  json: ["txid": txid, "address": address, "message": message ?? "", "signature": signature])
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+}


### PR DESCRIPTION
Adds a minimal Swift UI to call the local bridge:
- XMRService.swift client (health/address/estimate/transfer/tx/proof/verify)
- SendXMRSheet.swift: estimate → show fee → transfer → poll to 1 confirmation

Note: requires ATS exception for 127.0.0.1 (macOS target Info.plist). Snippet in comments.