### PR TITLE
macOS: bundle & auto-launch monero-wallet-rpc (stagenet)

### DIFF
--- a/bitchat/Monero/SendXMRSheet.swift
+++ b/bitchat/Monero/SendXMRSheet.swift
@@ -1,84 +1,285 @@
-﻿import SwiftUI
+﻿//
+// SendXMRSheet.swift
+// bitchat
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import SwiftUI
 
 struct SendXMRSheet: View {
-    @Environment(\.dismiss) private var dismiss
-    private let xmr = XMRClient()
+    // Optional defaults coming from ContentView’s detector
+    let addressDefault: String?
+    let amountDefault: Double?
 
-    @State private var address = ""
-    @State private var amountStr = "0.005"
-    @State private var fee: Double?
-    @State private var txid = ""
-    @State private var status = ""
-    @State private var isBusy = false
-    @State private var error: String?
+    // If you want to pass a custom bridge base, change here or make it configurable
+    private let bridgeBase = URL(string: "http://127.0.0.1:8787")!
+
+    // UI state
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var address: String = ""
+    @State private var amountText: String = ""
+    @State private var note: String = ""
+
+    @State private var isEstimating = false
+    @State private var isSending = false
+
+    @State private var feeXMR: Double? = nil
+    @State private var txid: String? = nil
+    @State private var errorMessage: String? = nil
+    @State private var confirmations: Int? = nil
+    @State private var inPool: Bool? = nil
+
+    // Synthesized init so calls without args still compile
+    init(addressDefault: String? = nil, amountDefault: Double? = nil) {
+        self.addressDefault = addressDefault
+        self.amountDefault = amountDefault
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Send Monero").font(.title2).bold()
-
-            TextField("Destination address", text: )
-                .textFieldStyle(.roundedBorder)
-
-            HStack(spacing: 12) {
-                TextField("Amount (XMR)", text: )
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 180)
-                if let f = fee {
-                    Text("Fee ≈ \(String(format: "%.8f", f)) XMR")
-                        .foregroundStyle(.secondary)
-                }
+            HStack {
+                Text("Send XMR (stagenet)")
+                    .font(.system(size: 16, weight: .semibold, design: .monospaced))
                 Spacer()
+                Button("Close") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
             }
 
-            if !txid.isEmpty {
-                Text("txid: \(txid)").font(.footnote).textSelection(.enabled)
+            Group {
+                TextField("Recipient subaddress", text: $address)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
+
+                HStack(spacing: 8) {
+                    TextField("Amount (XMR)", text: $amountText)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                        .onChange(of: amountText) { _ in feeXMR = nil } // reset estimate on change
+
+                    if let fee = feeXMR {
+                        Text(String(format: "fee ≈ %.8f XMR", fee))
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                TextField("Note (optional, for proof message)", text: $note)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.body, design: .monospaced))
             }
-            if !status.isEmpty {
-                Text(status).font(.footnote).foregroundStyle(.secondary)
+
+            if let txid {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("txid:")
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    Text(txid)
+                        .font(.system(size: 12, design: .monospaced))
+                        .textSelection(.enabled)
+
+                    if let confs = confirmations {
+                        Text("confirmations: \(confs)")
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(confs >= 10 ? .green : .secondary)
+                    }
+                    if let pool = inPool {
+                        Text(pool ? "in mempool" : "confirmed on chain")
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(pool ? .orange : .green)
+                    }
+                }
+                .padding(.top, 4)
             }
-            if let e = error {
-                Text(e).foregroundStyle(.red).font(.footnote)
+
+            if let err = errorMessage {
+                Text(err)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(.red)
             }
 
             HStack {
-                Button("Estimate") { Task { await doEstimate() } }.disabled(isBusy)
-                Button("Send") { Task { await doSend() } }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isBusy || fee == nil)
+                Button {
+                    Task { await estimate() }
+                } label: {
+                    if isEstimating {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Estimate Fee")
+                    }
+                }
+                .disabled(!canEstimate || isEstimating || isSending)
+                .buttonStyle(.bordered)
+
+                Button {
+                    Task { await send() }
+                } label: {
+                    if isSending {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Send")
+                    }
+                }
+                .disabled(!canSend || isSending)
+
                 Spacer()
-                Button("Close") { dismiss() }
+                if txid != nil {
+                    Button("Check Status") {
+                        Task { await refreshTxStatus() }
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .padding(.top, 6)
+        }
+        .padding(16)
+        .frame(minWidth: 520)
+        .onAppear {
+            // Prefill defaults once
+            if address.isEmpty, let a = addressDefault { address = a }
+            if amountText.isEmpty, let amt = amountDefault {
+                amountText = String(format: "%.12g", amt)
             }
         }
-        .padding(20)
-        .frame(minWidth: 520)
     }
 
-    private func amount() -> Double? { Double(amountStr.replacingOccurrences(of: ",", with: ".")) }
+    // MARK: - Validation
 
-    private func doEstimate() async {
-        error = nil; fee = nil; status = ""
-        guard let amt = amount(), !address.isEmpty else { error = "Enter address and amount"; return }
-        isBusy = true; defer { isBusy = false }
-        do {
-            let r = try await xmr.estimate(address: address, amount: amt)
-            fee = r.feeXmr
-        } catch { self.error = error.localizedDescription }
+    private var parsedAmount: Double? {
+        // Accept commas or spaces, normalize
+        let normalized = amountText
+            .replacingOccurrences(of: ",", with: ".")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return Double(normalized)
     }
 
-    private func doSend() async {
-        error = nil; status = ""; txid = ""
-        guard let amt = amount(), !address.isEmpty else { error = "Enter address and amount"; return }
-        isBusy = true; defer { isBusy = false }
+    private var canEstimate: Bool {
+        !address.trimmingCharacters(in: .whitespaces).isEmpty && (parsedAmount ?? 0) > 0
+    }
+
+    private var canSend: Bool {
+        canEstimate && feeXMR != nil // require an estimate first (your UX choice)
+    }
+
+    // MARK: - Networking
+
+    private func estimate() async {
+        errorMessage = nil
+        feeXMR = nil
+        confirmations = nil
+        inPool = nil
+        isEstimating = true
+        defer { isEstimating = false }
+
+        guard let amount = parsedAmount else {
+            errorMessage = "Enter a valid amount."
+            return
+        }
+
         do {
-            let r = try await xmr.transfer(address: address, amount: amt)
-            txid = r.txid ?? r.txHash ?? ""
-            status = "Broadcasted. Waiting for confirmations…"
-            while true {
-                try await Task.sleep(nanoseconds: 1_000_000_000)
-                let t = try await xmr.txStatus(txid: txid)
-                status = "Confirmations: \(t.confirmations)"
-                if t.confirmations >= 1 { break }
+            let url = bridgeBase.appendingPathComponent("estimate")
+            var req = URLRequest(url: url)
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            let body: [String: Any] = [
+                "address": address,
+                "amount": amount
+            ]
+            req.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            try ensureOK(resp)
+
+            if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let fee = json["fee_xmr"] as? Double {
+                feeXMR = fee
+            } else {
+                throw SimpleError("Unexpected estimate response.")
             }
-        } catch { self.error = error.localizedDescription }
+        } catch {
+            errorMessage = "Estimate failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func send() async {
+        errorMessage = nil
+        isSending = true
+        defer { isSending = false }
+
+        guard let amount = parsedAmount else {
+            errorMessage = "Enter a valid amount."
+            return
+        }
+
+        do {
+            let url = bridgeBase.appendingPathComponent("transfer")
+            var req = URLRequest(url: url)
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            let body: [String: Any] = [
+                "address": address,
+                "amount": amount,
+                "description": note
+            ]
+            req.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            try ensureOK(resp)
+
+            if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                // Bridge might return txid or tx_hash
+                let id = (json["txid"] as? String) ?? (json["tx_hash"] as? String)
+                guard let id else { throw SimpleError("No txid in response.") }
+                txid = id
+                feeXMR = json["fee_xmr"] as? Double ?? feeXMR
+
+                // Immediately get status once
+                await refreshTxStatus()
+            } else {
+                throw SimpleError("Unexpected transfer response.")
+            }
+        } catch {
+            errorMessage = "Send failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func refreshTxStatus() async {
+        guard let id = txid else { return }
+        errorMessage = nil
+        confirmations = nil
+        inPool = nil
+
+        do {
+            let url = bridgeBase.appendingPathComponent("tx/\(id)")
+            let (data, resp) = try await URLSession.shared.data(from: url)
+            try ensureOK(resp)
+
+            if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                confirmations = json["confirmations"] as? Int
+                inPool = json["in_pool"] as? Bool
+            } else {
+                throw SimpleError("Unexpected tx response.")
+            }
+        } catch {
+            errorMessage = "Status check failed: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func ensureOK(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw SimpleError("HTTP \(code)")
+        }
+    }
+
+    private struct SimpleError: LocalizedError {
+        let message: String
+        init(_ message: String) { self.message = message }
+        var errorDescription: String? { message }
     }
 }

--- a/bitchat/Monero/SendXMRSheet.swift
+++ b/bitchat/Monero/SendXMRSheet.swift
@@ -1,0 +1,84 @@
+﻿import SwiftUI
+
+struct SendXMRSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    private let xmr = XMRClient()
+
+    @State private var address = ""
+    @State private var amountStr = "0.005"
+    @State private var fee: Double?
+    @State private var txid = ""
+    @State private var status = ""
+    @State private var isBusy = false
+    @State private var error: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Send Monero").font(.title2).bold()
+
+            TextField("Destination address", text: )
+                .textFieldStyle(.roundedBorder)
+
+            HStack(spacing: 12) {
+                TextField("Amount (XMR)", text: )
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 180)
+                if let f = fee {
+                    Text("Fee ≈ \(String(format: "%.8f", f)) XMR")
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+
+            if !txid.isEmpty {
+                Text("txid: \(txid)").font(.footnote).textSelection(.enabled)
+            }
+            if !status.isEmpty {
+                Text(status).font(.footnote).foregroundStyle(.secondary)
+            }
+            if let e = error {
+                Text(e).foregroundStyle(.red).font(.footnote)
+            }
+
+            HStack {
+                Button("Estimate") { Task { await doEstimate() } }.disabled(isBusy)
+                Button("Send") { Task { await doSend() } }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isBusy || fee == nil)
+                Spacer()
+                Button("Close") { dismiss() }
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 520)
+    }
+
+    private func amount() -> Double? { Double(amountStr.replacingOccurrences(of: ",", with: ".")) }
+
+    private func doEstimate() async {
+        error = nil; fee = nil; status = ""
+        guard let amt = amount(), !address.isEmpty else { error = "Enter address and amount"; return }
+        isBusy = true; defer { isBusy = false }
+        do {
+            let r = try await xmr.estimate(address: address, amount: amt)
+            fee = r.feeXmr
+        } catch { self.error = error.localizedDescription }
+    }
+
+    private func doSend() async {
+        error = nil; status = ""; txid = ""
+        guard let amt = amount(), !address.isEmpty else { error = "Enter address and amount"; return }
+        isBusy = true; defer { isBusy = false }
+        do {
+            let r = try await xmr.transfer(address: address, amount: amt)
+            txid = r.txid ?? r.txHash ?? ""
+            status = "Broadcasted. Waiting for confirmations…"
+            while true {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                let t = try await xmr.txStatus(txid: txid)
+                status = "Confirmations: \(t.confirmations)"
+                if t.confirmations >= 1 { break }
+            }
+        } catch { self.error = error.localizedDescription }
+    }
+}

--- a/bitchat/Monero/WalletRPCLauncher.swift
+++ b/bitchat/Monero/WalletRPCLauncher.swift
@@ -1,0 +1,131 @@
+﻿#if os(macOS)
+//
+// WalletRPCLauncher.swift (macOS)
+// bitchat – bundles & spawns monero-wallet-rpc locally
+// Public domain – https://unlicense.org
+//
+
+import Foundation
+
+final class WalletRPCLauncher {
+    static let shared = WalletRPCLauncher()
+    private init() {}
+
+    private let fm = FileManager.default
+
+    private var appSupport: URL {
+        let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let dir = base.appendingPathComponent("bitchat", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+    private var binDir: URL { appSupport.appendingPathComponent("bin", isDirectory: true) }
+    private var walletsDir: URL { appSupport.appendingPathComponent("wallets", isDirectory: true) }
+    private var logsDir: URL { appSupport.appendingPathComponent("logs", isDirectory: true) }
+    private var rpcDst: URL { binDir.appendingPathComponent("monero-wallet-rpc") }
+    private var walletPath: URL { walletsDir.appendingPathComponent("demo") }
+    private var logPath: URL { logsDir.appendingPathComponent("wallet-rpc.log") }
+
+    private var process: Process?
+
+    private func ensureInstalledFromBundle() throws {
+        try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: walletsDir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        if !fm.fileExists(atPath: rpcDst.path) {
+            guard let src = Bundle.main.url(forResource: "monero-wallet-rpc", withExtension: nil) else {
+                throw NSError(domain: "WalletRPC", code: 1,
+                              userInfo: [NSLocalizedDescriptionKey: "Bundled monero-wallet-rpc not found in app resources"])
+            }
+            try fm.copyItem(at: src, to: rpcDst)
+            // make it executable
+            let chmod = Process()
+            chmod.executableURL = URL(fileURLWithPath: "/bin/chmod")
+            chmod.arguments = ["+x", rpcDst.path]
+            try? chmod.run()
+            chmod.waitUntilExit()
+        }
+    }
+
+    @discardableResult
+    func startIfNeeded(
+        stagenet: Bool = true,
+        port: Int = 18083,
+        daemonURL envDaemon: String? = ProcessInfo.processInfo.environment["BITCHAT_DAEMON_URL"]
+    ) throws -> Int {
+        if process?.isRunning == true { return port }
+        try ensureInstalledFromBundle()
+
+        let daemonURL = envDaemon ?? "http://127.0.0.1:38081"
+
+        if !fm.fileExists(atPath: logPath.path) { fm.createFile(atPath: logPath.path, contents: nil) }
+        let logHandle = try FileHandle(forWritingTo: logPath)
+        try? logHandle.seekToEnd()
+
+        let p = Process()
+        p.executableURL = rpcDst
+        var args: [String] = []
+        if stagenet { args.append("--stagenet") }
+        args += [
+            "--daemon-address", daemonURL,
+            "--trusted-daemon",
+            "--rpc-bind-ip", "127.0.0.1",
+            "--rpc-bind-port", "\(port)",
+            "--disable-rpc-login",
+            "--wallet-file", walletPath.path,
+            "--password", "XMRm4x!2025secure",
+            "--log-level", "1"
+        ]
+        p.arguments = args
+        p.standardOutput = logHandle
+        p.standardError  = logHandle
+        try p.run()
+        process = p
+
+        // Wait until wallet-rpc answers get_version (≤15s)
+        let ok = waitReadyJSONRPC(URL(string: "http://127.0.0.1:\(port)/json_rpc")!, timeout: 15)
+        if !ok {
+            stop()
+            throw NSError(domain: "WalletRPC", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "wallet-rpc did not become ready (see \(logPath.path))"])
+        }
+        return port
+    }
+
+    func stop() {
+        guard let p = process, p.isRunning else { return }
+        p.terminate()
+        process = nil
+    }
+
+    private func waitReadyJSONRPC(_ url: URL, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        let body: [String: Any] = ["jsonrpc":"2.0","id":0,"method":"get_version"]
+        let payload = try? JSONSerialization.data(withJSONObject: body)
+
+        while Date() < deadline {
+            var req = URLRequest(url: url)
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = payload
+
+            let sem = DispatchSemaphore(value: 0)
+            var ok = false
+            URLSession.shared.dataTask(with: req) { data, resp, _ in
+                if let http = resp as? HTTPURLResponse, (200...299).contains(http.statusCode),
+                   let d = data,
+                   let obj = try? JSONSerialization.jsonObject(with: d) as? [String:Any],
+                   obj["result"] != nil {
+                    ok = true
+                }
+                sem.signal()
+            }.resume()
+            _ = sem.wait(timeout: .now() + 0.5)
+            if ok { return true }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        return false
+    }
+}
+#endif

--- a/bitchat/Monero/XMRDetect.swift
+++ b/bitchat/Monero/XMRDetect.swift
@@ -1,0 +1,66 @@
+﻿import Foundation
+
+public struct XMRIntent {
+    public let address: String
+    public let amount: Double?
+}
+
+private let addrRegex: NSRegularExpression = {
+    // 95-char (primary) or 106-char (subaddress)
+    // Prefixes:
+    //  - mainnet: '4' (primary), '8' (subaddress)
+    //  - stagenet/testnet: '5' (primary), '7' (subaddress)
+    let pattern = #"(?:(?:[4|5])[0-9A-Za-z]{94}|(?:[7|8])[0-9A-Za-z]{105})"#
+    return try! NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+}()
+
+public func isXMRAddress(_ s: String) -> Bool {
+    let len = s.count
+    guard (len == 95 || len == 106) else { return false }
+    let r = NSRange(location: 0, length: s.utf16.count)
+    return addrRegex.firstMatch(in: s, options: [], range: r) != nil
+}
+
+private func findNearbyAmount(in s: String) -> Double? {
+    // Matches: 0.01, 0,01, "0.01 XMR", "amount=0.01"
+    let rx = try! NSRegularExpression(pattern: #"(?:^|[^\d])(\d+(?:[.,]\d+)?)(?:\s*)(?:xmr|XMR)?\b"#)
+    let r = NSRange(location: 0, length: s.utf16.count)
+    if let m = rx.firstMatch(in: s, options: [], range: r), m.numberOfRanges >= 2,
+       let rr = Range(m.range(at: 1), in: s) {
+        let raw = String(s[rr]).replacingOccurrences(of: ",", with: ".")
+        return Double(raw)
+    }
+    return nil
+}
+
+public func parseXMRIntent(_ text: String) -> XMRIntent? {
+    let s = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    // 1) monero: URI
+    if s.lowercased().hasPrefix("monero:"),
+       let url = URL(string: s) {
+        // Address can be host or path depending on the URI form
+        let addrCandidate = (url.host?.isEmpty == false) ? url.host! : url.path.replacingOccurrences(of: "/", with: "")
+        guard isXMRAddress(addrCandidate) else { return nil }
+
+        var amount: Double? = nil
+        if let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           let qs = comps.queryItems {
+            if let a = qs.first(where: { .name.lowercased() == "tx_amount" || .name.lowercased() == "amount" })?.value {
+                amount = Double(a.replacingOccurrences(of: ",", with: "."))
+            }
+        }
+        return XMRIntent(address: addrCandidate, amount: amount)
+    }
+
+    // 2) raw address in free text
+    let r = NSRange(location: 0, length: s.utf16.count)
+    if let m = addrRegex.firstMatch(in: s, options: [], range: r),
+       let rr = Range(m.range, in: s) {
+        let address = String(s[rr])
+        let amt = findNearbyAmount(in: s)
+        return XMRIntent(address: address, amount: amt)
+    }
+
+    return nil
+}

--- a/bitchat/Monero/XMRService.swift
+++ b/bitchat/Monero/XMRService.swift
@@ -1,0 +1,87 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+#endif
+
+// Basic config
+enum XMRConfig {
+    static let baseURL = URL(string: "http://127.0.0.1:8787")! // your bridge
+    static let apiKey: String? = nil // set if you enabled XMR_BRIDGE_KEY
+}
+
+// Generic client
+final class XMRClient {
+    private let session: URLSession = .shared
+
+    private func makeRequest(path: String, method: String = "GET", json: Any? = nil) throws -> URLRequest {
+        var req = URLRequest(url: XMRConfig.baseURL.appendingPathComponent(path))
+        req.httpMethod = method
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let k = XMRConfig.apiKey { req.setValue(k, forHTTPHeaderField: "x-api-key") }
+        if let json {
+            req.httpBody = try JSONSerialization.data(withJSONObject: json, options: [])
+        }
+        return req
+    }
+
+    private func decode<T: Decodable>(_ data: Data) throws -> T {
+        let dec = JSONDecoder()
+        dec.keyDecodingStrategy = .convertFromSnakeCase
+        return try dec.decode(T.self, from: data)
+    }
+
+    // MARK: DTOs
+    struct Health: Decodable { let ok: Bool; let version: Int?; let release: Bool? }
+    struct AddressResp: Decodable { let ok: Bool?; let address: String; let addressIndex: Int?; let accountIndex: Int? }
+    struct EstimateResp: Decodable { let feeXmr: Double; let txMetadata: String }
+    struct TransferResp: Decodable { let ok: Bool?; let txid: String?; let txHash: String?; let feeXmr: Double? }
+    struct TxResp: Decodable { let ok: Bool?; let txid: String; let inPool: Bool; let confirmations: Int; let amountXmr: Double; let feeXmr: Double?; let timestamp: TimeInterval? }
+    struct ProofResp: Decodable { let ok: Bool?; let txid: String; let address: String; let message: String?; let signature: String }
+    struct VerifyResp: Decodable { let ok: Bool?; let good: Bool; let inPool: Bool; let receivedXmr: Double }
+
+    // MARK: Calls
+    func health() async throws -> Health {
+        let req = try makeRequest(path: "health")
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func createAddress(label: String) async throws -> AddressResp {
+        let req = try makeRequest(path: "address", method: "POST", json: ["label": label])
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func estimate(address: String, amount: Double) async throws -> EstimateResp {
+        let req = try makeRequest(path: "estimate", method: "POST", json: ["address": address, "amount": amount])
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func transfer(address: String, amount: Double) async throws -> TransferResp {
+        let req = try makeRequest(path: "transfer", method: "POST", json: ["address": address, "amount": amount])
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func txStatus(txid: String) async throws -> TxResp {
+        let req = try makeRequest(path: "tx/\(txid)")
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func createProof(txid: String, address: String, message: String?) async throws -> ProofResp {
+        var body: [String: Any] = ["txid": txid, "address": address]
+        if let m = message { body["message"] = m }
+        let req = try makeRequest(path: "proof", method: "POST", json: body)
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+
+    func verifyProof(txid: String, address: String, message: String?, signature: String) async throws -> VerifyResp {
+        let req = try makeRequest(path: "verify", method: "POST",
+                                  json: ["txid": txid, "address": address, "message": message ?? "", "signature": signature])
+        let (d, _) = try await session.data(for: req)
+        return try decode(d)
+    }
+}

--- a/tools/start_stack.ps1
+++ b/tools/start_stack.ps1
@@ -1,0 +1,134 @@
+<#
+Start the full local Monero stagenet stack on Windows:
+- monerod.exe (stagenet)
+- monero-wallet-rpc.exe (stagenet)
+- Node bridge (tools\xmr-bridge)
+
+Creates logs in .\logs\ and verifies health endpoints.
+#>
+
+[CmdletBinding()]
+param(
+  [string]$DaemonHost = "127.0.0.1",
+  [int]$DaemonPort = 38081,
+  [string]$WalletRpcHost = "127.0.0.1",
+  [int]$WalletRpcPort = 18083,
+  [string]$WalletFile = ".\demo",
+  [string]$WalletPassword = "XMRm4x!2025secure",
+  [string]$BridgeDir = ".\tools\xmr-bridge",
+  [int]$BridgePort = 8787
+)
+
+$ErrorActionPreference = "Stop"
+$root = (Resolve-Path .).Path
+$logs = Join-Path $root "logs"
+New-Item -ItemType Directory -Force -Path $logs | Out-Null
+
+function Start-Proc {
+  param([string]$Name, [string]$Exe, [string]$Args, [string]$Log)
+  Write-Host "▶ Starting $Name..." -ForegroundColor Cyan
+  $si = New-Object System.Diagnostics.ProcessStartInfo
+  $si.FileName = $Exe
+  $si.Arguments = $Args
+  $si.WorkingDirectory = Split-Path $Exe
+  $si.RedirectStandardOutput = $true
+  $si.RedirectStandardError  = $true
+  $si.UseShellExecute = $false
+  $si.CreateNoWindow = $true
+  $p = New-Object System.Diagnostics.Process
+  $p.StartInfo = $si
+  $null = $p.Start()
+  $p.StandardOutput.BeginReadLine()
+  $p.StandardError.BeginReadLine()
+  $outLog = Join-Path $logs $Log
+  Register-ObjectEvent -InputObject $p -EventName OutputDataReceived -Action {
+    if ($EventArgs.Data) { Add-Content -Path $args[0] -Value $EventArgs.Data }
+  } -MessageData $outLog | Out-Null
+  Register-ObjectEvent -InputObject $p -EventName ErrorDataReceived -Action {
+    if ($EventArgs.Data) { Add-Content -Path $args[0] -Value $EventArgs.Data }
+  } -MessageData $outLog | Out-Null
+  return $p
+}
+
+function Wait-HttpOk {
+  param([string]$Url, [int]$TimeoutSec = 60)
+  $sw = [Diagnostics.Stopwatch]::StartNew()
+  while ($sw.Elapsed.TotalSeconds -lt $TimeoutSec) {
+    try {
+      $r = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 5
+      if ($r.StatusCode -ge 200 -and $r.StatusCode -lt 300) { return $true }
+    } catch { Start-Sleep 1 }
+  }
+  return $false
+}
+
+# Locate executables (assumes they’re in repo root; tweak if different)
+$monerod = Join-Path $root "monerod.exe"
+$wallet  = Join-Path $root "monero-wallet-rpc.exe"
+
+if (!(Test-Path $monerod)) { throw "monerod.exe not found at $monerod" }
+if (!(Test-Path $wallet))  { throw "monero-wallet-rpc.exe not found at $wallet" }
+if (!(Test-Path $BridgeDir)) { throw "Bridge dir not found: $BridgeDir" }
+
+# 1) monerod (stagenet)
+$daemonArgs = @(
+  "--stagenet",
+  "--rpc-bind-ip", $DaemonHost,
+  "--rpc-bind-port", $DaemonPort,
+  "--prune-blockchain",
+  "--db-sync-mode", "fast:async:1000000",
+  "--max-concurrency", "2"
+) -join " "
+$procDaemon = Start-Proc -Name "monerod" -Exe $monerod -Args $daemonArgs -Log "daemon.log"
+
+# 2) wallet-rpc (stagenet)
+$walletArgs = @(
+  "--stagenet",
+  "--daemon-address", "http://$DaemonHost`:$DaemonPort",
+  "--trusted-daemon",
+  "--rpc-bind-ip", $WalletRpcHost,
+  "--rpc-bind-port", $WalletRpcPort,
+  "--disable-rpc-login",
+  "--wallet-file", $WalletFile,
+  "--password", $WalletPassword,
+  "--log-level", "1"
+) -join " "
+$procWallet = Start-Proc -Name "wallet-rpc" -Exe $wallet -Args $walletArgs -Log "wallet-rpc.log"
+
+# 3) Node bridge
+Push-Location $BridgeDir
+$env:WALLET_RPC_URL = "http://$WalletRpcHost`:$WalletRpcPort/json_rpc"
+$procBridge = Start-Proc -Name "bridge" -Exe "npm.cmd" -Args "start" -Log "bridge.log"
+Pop-Location
+
+# Health checks
+Write-Host "⏳ Waiting for daemon / wallet / bridge to respond..." -ForegroundColor Yellow
+
+$okDaemon = Wait-HttpOk -Url "http://$DaemonHost`:$DaemonPort/get_info"
+$okWallet = $false
+try {
+  $body = @{ jsonrpc="2.0"; id=0; method="get_version" } | ConvertTo-Json
+  $r = Invoke-WebRequest -Uri "http://$WalletRpcHost`:$WalletRpcPort/json_rpc" -Method POST -ContentType 'application/json' -Body $body -UseBasicParsing -TimeoutSec 5
+  if ($r.StatusCode -ge 200 -and $r.StatusCode -lt 300) { $okWallet = $true }
+} catch { }
+
+$okBridge = Wait-HttpOk -Url "http://127.0.0.1:$BridgePort/health"
+
+# Status output without ternary (compatible PS5/PS7)
+$daemonStatus = if ($okDaemon) { "OK" } else { "FAIL" }
+$walletStatus = if ($okWallet) { "OK" } else { "FAIL" }
+$bridgeStatus = if ($okBridge) { "OK" } else { "FAIL" }
+
+Write-Host "daemon: $daemonStatus"
+Write-Host "wallet-rpc: $walletStatus"
+Write-Host "bridge: $bridgeStatus"
+
+if (-not $okBridge) {
+  Write-Warning "Bridge not healthy yet. Tail logs in .\logs\bridge.log"
+} else {
+  try { Start-Process "http://127.0.0.1:$BridgePort/health" } catch { }
+}
+
+Write-Host "✅ Stack started. Logs in: $logs" -ForegroundColor Green
+Write-Host "Press Ctrl+C to stop (or kill processes manually)." -ForegroundColor Yellow
+


### PR DESCRIPTION
What
- Ship `monero-wallet-rpc` with the app (macOS).
- On first run, copy to `~/Library/Application Support/bitchat/bin/` and make it executable.
- Auto-start on app launch with stagenet flags; wait until `get_version` answers on `http://127.0.0.1:18083/json_rpc`.
- Logs: `~/Library/Application Support/bitchat/logs/wallet-rpc.log`.

Files
- bitchat/Monero/WalletRPCLauncher.swift  (install/start/stop + readiness poll)
- scripts/copy-wallet-rpc.sh              (build phase: copy binary into app Resources)
- .gitignore tweaks

Build setup
1) Place the macOS binary at: `ThirdParty/monero/macos/monero-wallet-rpc`
2) In macOS target → **Build Phases**, add a **Run Script** *above* “Copy Bundle Resources”:
   `bash "${PROJECT_DIR}/scripts/copy-wallet-rpc.sh"`
3) Ensure ATS allows `localhost` / `127.0.0.1` HTTP in the macOS target’s Info.plist.

How to test
1) Build & run the macOS app.
2) Confirm wallet-rpc is up:
   - Log file: `~/Library/Application Support/bitchat/logs/wallet-rpc.log`
   - Or:
     ```
     curl -s http://127.0.0.1:18083/json_rpc \
       -H "Content-Type: application/json" \
       -d '{ "jsonrpc":"2.0","id":0,"method":"get_version" }'
     ```
3) Use the existing bridge / Send-XMR UI to: estimate → send → check tx status.

Config
- Defaults: stagenet, daemon `http://127.0.0.1:38081`.
- Optional: `BITCHAT_DAEMON_URL=http://host:port`.

Notes
- This does not bundle `monerod`. Windows flow unchanged.
